### PR TITLE
Fixes for BIFC V1 format and all found inconistencies regarding signature and version

### DIFF
--- a/file_formats/ie_formats/bam_v1.htm
+++ b/file_formats/ie_formats/bam_v1.htm
@@ -66,7 +66,7 @@ This file format describes animated graphics. Such files are used for animations
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V1 ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>
@@ -274,7 +274,7 @@ This file format describes animated graphics. Such files are used for animations
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V1 ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/bif_v1.htm
+++ b/file_formats/ie_formats/bif_v1.htm
@@ -250,17 +250,17 @@ title: "BIFF file format"
             <td>Filename (length specified by previous field)</td>
           </tr>
           <tr>
-            <td>sizeof(filename)+0x0010</td>
+            <td>sizeof(filename)+0x000C</td>
             <td>4 (dword)</td>
             <td>Uncompressed data length</td>
           </tr>
           <tr>
-            <td>sizeof(filename)+0x0014</td>
+            <td>sizeof(filename)+0x0010</td>
             <td>4 (dword)</td>
             <td>Compressed data length</td>
           </tr>
           <tr>
-            <td>sizeof(filename)+0x0018</td>
+            <td>sizeof(filename)+0x0014</td>
             <td>Variable (raw data)</td>
             <td>Compressed data</td>
           </tr>

--- a/file_formats/ie_formats/bif_v1.htm
+++ b/file_formats/ie_formats/bif_v1.htm
@@ -72,7 +72,7 @@ title: "BIFF file format"
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V1 ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/chr_v1.2.htm
+++ b/file_formats/ie_formats/chr_v1.2.htm
@@ -48,12 +48,12 @@ title: "CHR file format"
         <tbody>
         <tr>
           <td>0x0000</td>
-          <td>4(char array)</td>
+          <td>4 (char array)</td>
           <td>Signature ('CHR ')</td>
         </tr>
         <tr>
           <td>0x0004</td>
-          <td>4(char array)</td>
+          <td>4 (char array)</td>
           <td>Version ('V1.2')</td>
         </tr>
         <tr>

--- a/file_formats/ie_formats/chr_v1.htm
+++ b/file_formats/ie_formats/chr_v1.htm
@@ -48,12 +48,12 @@ title: "CHR file format"
         <tbody>
         <tr>
           <td>0x0000</td>
-          <td>4(char array)</td>
+          <td>4 (char array)</td>
           <td>Signature ('CHR ')</td>
         </tr>
         <tr>
           <td>0x0004</td>
-          <td>4(char array)</td>
+          <td>4 (char array)</td>
           <td>Version ('V1.0')</td>
         </tr>
         <tr>

--- a/file_formats/ie_formats/chr_v2.2.htm
+++ b/file_formats/ie_formats/chr_v2.2.htm
@@ -48,12 +48,12 @@ title: "CHR file format"
         <tbody>
           <tr>
             <td>0x0000</td>
-            <td>4(char array)</td>
+            <td>4 (char array)</td>
             <td>Signature ('CHR ')</td>
           </tr>
           <tr>
             <td>0x0004</td>
-            <td>4(char array)</td>
+            <td>4 (char array)</td>
             <td>Version ('V2.2')</td>
           </tr>
           <tr>

--- a/file_formats/ie_formats/chr_v2.htm
+++ b/file_formats/ie_formats/chr_v2.htm
@@ -48,12 +48,12 @@ title: "CHR file format"
         <tbody>
         <tr>
           <td>0x0000</td>
-          <td>4(char array)</td>
+          <td>4 (char array)</td>
           <td>Signature ('CHR ')</td>
         </tr>
         <tr>
           <td>0x0004</td>
-          <td>4(char array)</td>
+          <td>4 (char array)</td>
           <td>Version ('V2.0')</td>
         </tr>
         <tr>

--- a/file_formats/ie_formats/chu_v1.htm
+++ b/file_formats/ie_formats/chu_v1.htm
@@ -50,7 +50,7 @@ title: "CHUI file format"
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V1 ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/dlg_v1.htm
+++ b/file_formats/ie_formats/dlg_v1.htm
@@ -68,7 +68,7 @@ title: "DLG file format"
         <tr>
           <td>0x0004</td>
           <td>4 (char array)</td>
-          <td>Version ('V1.09')</td>
+          <td>Version ('V1.0')</td>
         </tr>
         <tr>
           <td>0x0008</td>

--- a/file_formats/ie_formats/itm_v1.htm
+++ b/file_formats/ie_formats/itm_v1.htm
@@ -65,7 +65,7 @@ title: "ITM file format"
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version('V1  ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/key_v1.htm
+++ b/file_formats/ie_formats/key_v1.htm
@@ -50,7 +50,7 @@ title: "KEY file format"
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V1 ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/mos_v1.htm
+++ b/file_formats/ie_formats/mos_v1.htm
@@ -57,7 +57,7 @@ title: "MOS file format"
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V1 ')</td>
+            <td>Version ('V1 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/mos_v2.htm
+++ b/file_formats/ie_formats/mos_v2.htm
@@ -48,7 +48,7 @@ title: "MOS file format"
           <tr>
             <td>0x0004</td>
             <td>4 (char array)</td>
-            <td>Version ('V2 ')</td>
+            <td>Version ('V2 &nbsp;')</td>
           </tr>
           <tr>
             <td>0x0008</td>

--- a/file_formats/ie_formats/plt_v1.htm
+++ b/file_formats/ie_formats/plt_v1.htm
@@ -45,13 +45,13 @@ title: "PLT file format"
       </thead>
       <tr>
         <td>0x00000</td>
-        <td>4 (ASCIIZ string)</td>
+        <td>4 (char array)</td>
         <td>Signature ('PLT ')</td>
       </tr>
       <tr>
         <td>0x00004</td>
-        <td>4 (ASCIIZ string)</td>
-        <td>Version 'V1&nbsp; '</td>
+        <td>4 (char array)</td>
+        <td>Version ('V1 &nbsp;')</td>
       </tr>
       <tr>
         <td>0x00008</td>

--- a/file_formats/ie_formats/spl_v1.htm
+++ b/file_formats/ie_formats/spl_v1.htm
@@ -65,7 +65,7 @@ title: "SPL file format"
         <tr>
           <td>0x0004</td>
           <td>4 (char array)</td>
-          <td>Version ('V1   ')</td>
+          <td>Version ('V1 &nbsp;')</td>
         </tr>
         <tr>
           <td>0x0008</td>

--- a/file_formats/ie_formats/tlk_v1.htm
+++ b/file_formats/ie_formats/tlk_v1.htm
@@ -49,7 +49,7 @@ title: "TLK file format"
         <tr>
           <td>0x0004</td>
           <td>4 (char array)</td>
-          <td>Version ('V1 ')</td>
+          <td>Version ('V1 &nbsp;')</td>
         </tr>
         <tr>
           <td>0x0008</td>

--- a/file_formats/ie_formats/wavc_v1.htm
+++ b/file_formats/ie_formats/wavc_v1.htm
@@ -37,7 +37,7 @@ title: "WAVC file format"
         <tr>
           <td>0x0004</td>
           <td>4 (char array)</td>
-          <td>Version (V1.0)</td>
+          <td>Version ('V1.0')</td>
         </tr>
         <tr>
           <td>0x0008</td>


### PR DESCRIPTION
The dlg and bifc contains some small errors:

- dlg: version constant was 5 characters long
- bifc: wrong offsets for "Uncompressed data length", "Compressed data length" and "Compressed data" (checked using iwd files)

They are fixed with a commit per file type :)

UPDATE: added a commit to fix all inconsistencies found in signatures and version (missing braces, missing whitespaces)