### PR TITLE
remove untested mark from tested triggers

### DIFF
--- a/scripting/triggers/bg2triggers.htm
+++ b/scripting/triggers/bg2triggers.htm
@@ -267,7 +267,7 @@ title: "BG2: ToB Script Triggers"
     Only for trap scripts. Returns true only if the specified object detected this trap in the last script round.<br />
     <br />
     <strong>0x0055 Reset(O:Object*)</strong><br />
-    NT Only for trap scripts? Returns true only if this trap or trigger was reset in the last script round by the object specified.<br />
+    Only for trap scripts? Returns true only if this trap or trigger was reset in the last script round by the object specified.<br />
     <br />
     <strong>0x0056 Disarmed(O:Object*)</strong><br />
     Only for trap/trigger region scripts. Returns true only if the specified object disarmed this trap in the last script round.<br />
@@ -545,7 +545,7 @@ title: "BG2: ToB Script Triggers"
 </ul>
     <br />
     <strong>0x40B2 HasItemSlot(O:Object*,I:Slot*SLOTS)</strong><br />
-    NT Returns true only if the specified object has an item in the specified slot. This trigger does not work for Melf's Minute Meteors.<br />
+    Returns true only if the specified object has an item in the specified slot. This trigger does not work for Melf's Minute Meteors.<br />
     <br />
     <strong>0x40B3 PersonalSpaceDistance(O:Object*,I:Range*)</strong><br />
     NT Returns true if the specified object exactly as far away from the active CRE as the 2nd parameter specifies.<br />


### PR DESCRIPTION
[Reset()](https://github.com/BGforgeNet/bg2-tweaks-and-tricks/blob/b356da6d128f47869cba20628e8bf9a4bae656f6/tnt/easy_traps/traps.baf#L154) and [HasItemSlot()](https://github.com/BGforgeNet/bg2-tweaks-and-tricks/blob/b356da6d128f47869cba20628e8bf9a4bae656f6/tnt/smarter_familiars/g_fam.baf.tph#L175) are working properly in ToB.