### PR TITLE
add warning about target in opcode 265

### DIFF
--- a/_opcodes/op265.html
+++ b/_opcodes/op265.html
@@ -34,3 +34,9 @@ All timing modes act as permanent for this effect.
 {% endcapture %}
 
 {% include note.html %}
+
+{% capture note %}
+Make sure to set target. Target: Self (1) works well. If target is unset (0), the game will freeze.
+{% endcapture %}
+
+{% include warning.html %}


### PR DESCRIPTION
Set global var opcode freezes a game (ToB) if target is not set for the effect. Added a warning about that.