### PR TITLE
Decrementing reflection mechanics

### DIFF
--- a/_opcodes/op146.html
+++ b/_opcodes/op146.html
@@ -21,7 +21,7 @@ Casts the spell specified by the <code>resource</code> key at the level specifie
 {% capture note %}
 <ul>
 	<li>When this opcode gets reflected using <code>Type=1</code>, the spell specified by the <code>resource</code> key is cast at the target's Casting Level, not the caster's.</li>
-	<li>When this opcode gets reflected using <code>Type=2</code>, the spell specified by the <code>resource</code> key is cast at the specified <code>Casting Level</code>, and it will also affect the original target (as if it wasn't reflected – though it will decrement <a href="#op200">Spell Turning</a>).</li>
+	<li>When this opcode gets reflected (<a href="#op197">opcode #197</a>, <a href="#op198">opcode #198</a>, <a href="#op199">opcode #199</a>, <a href="#op202">opcode #202</a>, <a href="#op203">opcode #203</a> and <a href="#op207">opcode #207</a>) using <code>Type=2</code>, the spell specified by the <code>resource</code> key is cast at the specified <code>Casting Level</code>, and it will also affect the original target (as if it wasn't reflected).</li>
 </ul>
 {% endcapture %}
 

--- a/_opcodes/op197.html
+++ b/_opcodes/op197.html
@@ -21,7 +21,10 @@ The targeted creature(s) will reflect effects whose <code>Projectile</code> is e
 </p>
 
 {% capture note %}
-<a href="../file_formats/ie_formats/pro_v1.htm#0x8_3">Area-Effect</a> projectiles only impact through their <a href="../file_formats/ie_formats/pro_v1.htm#0x21A">explosion</a> and/or <a href="../file_formats/ie_formats/pro_v1.htm#0x214">secondary</a> projectiles, so they are what must be specified in <code>Impact Projectile</code>.
+<ul>
+	<li><a href="../file_formats/ie_formats/pro_v1.htm#0x8_3">Area-Effect</a> projectiles only impact through their <a href="../file_formats/ie_formats/pro_v1.htm#0x21A">explosion</a> and/or <a href="../file_formats/ie_formats/pro_v1.htm#0x214">secondary</a> projectiles, so they are what must be specified in <code>Impact Projectile</code>.</li>
+	<li><a href="#op333">Opcode #333</a>, <a href="#op326">opcode #326</a> and <a href="#op146">opcode #146</a><code><sup><small>*</small></sup>p2=2</code> are NOT properly reflected by this opcode – the spell specified by their <code>resource</code> key will affect the original target (as if it wasn't reflected).</li>
+</ul>
 {% endcapture %}
 
 {% include important.html %}

--- a/_opcodes/op198.html
+++ b/_opcodes/op198.html
@@ -19,6 +19,12 @@ This can cause a crash if two creatures end up reflecting to each other.
 {% include warning.html %}
 
 {% capture note %}
+<a href="#op333">Opcode #333</a>, <a href="#op326">opcode #326</a> and <a href="#op146">opcode #146</a><code><sup><small>*</small></sup>p2=2</code> are NOT properly reflected by this opcode – the spell specified by their <code>resource</code> key will affect the original target (as if it wasn't reflected).
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT reflect effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op199.html
+++ b/_opcodes/op199.html
@@ -13,6 +13,12 @@ pst: 0
 The targeted creature(s) will reflect effects whose <code>Power</code> attribute is equal to the one specified by the <code>Power Level</code> field (<code>range: 0 – 9</code>).
 
 {% capture note %}
+<a href="#op333">Opcode #333</a>, <a href="#op326">opcode #326</a> and <a href="#op146">opcode #146</a><code><sup><small>*</small></sup>p2=2</code> are NOT properly reflected by this opcode – the spell specified by their <code>resource</code> key will affect the original target (as if it wasn't reflected).
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT block effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op200.html
+++ b/_opcodes/op200.html
@@ -24,6 +24,14 @@ The targeted creature(s) will reflect a number of effects (specified by the <cod
 </p>
 
 {% capture note %}
+As of EE v2.6, spells can no longer be "chained" back and forth by reflection.<br><br>
+
+If Caster and Target are both affected by this opcode, the spell from Caster will reflect off Target, but not reflect back off Caster. Previously, whoever had more reflection charges would end up victorious, now the initial target always ends up victorious.
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT block effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op202.html
+++ b/_opcodes/op202.html
@@ -32,6 +32,12 @@ Known values for <code>School</code> are:
 </ul>
 
 {% capture note %}
+<a href="#op333">Opcode #333</a>, <a href="#op326">opcode #326</a> and <a href="#op146">opcode #146</a><code><sup><small>*</small></sup>p2=2</code> are NOT properly reflected by this opcode – the spell specified by their <code>resource</code> key will affect the original target (as if it wasn't reflected).
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT reflect effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op203.html
+++ b/_opcodes/op203.html
@@ -35,6 +35,12 @@ Known values for <code>Secondary Type</code> are:
 </ul>
 
 {% capture note %}
+<a href="#op333">Opcode #333</a>, <a href="#op326">opcode #326</a> and <a href="#op146">opcode #146</a><code><sup><small>*</small></sup>p2=2</code> are NOT properly reflected by this opcode – the spell specified by their <code>resource</code> key will affect the original target (as if it wasn't reflected).
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT reflect effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op207.html
+++ b/_opcodes/op207.html
@@ -13,6 +13,12 @@ pst: 0
 The targeted creature(s) will reflect the <a href="../file_formats/ie_formats/spl_v1.htm">SPL</a> file specified by the <code>resource</code> key.
 
 {% capture note %}
+<a href="#op333">Opcode #333</a>, <a href="#op326">opcode #326</a> and <a href="#op146">opcode #146</a><code><sup><small>*</small></sup>p2=2</code> are NOT properly reflected by this opcode – the spell specified by their <code>resource</code> key will affect the original target (as if it wasn't reflected).
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>Similar to <a href="#op206">opcode #206</a>, this can only reflect EFF files if their <code><a href="../file_formats/ie_formats/eff_v2.htm#effv2_Body_0x90">Parent Type</a></code> is set to <code><a href="../file_formats/ie_formats/eff_v2.htm#effv2_Body_0x90_1">Spell</a></code>.</li>
 	<li>

--- a/_opcodes/op227.html
+++ b/_opcodes/op227.html
@@ -40,6 +40,14 @@ Known values for <code>School</code> are:
 </p>
 
 {% capture note %}
+As of EE v2.6, spells can no longer be "chained" back and forth by reflection.<br><br>
+
+If Caster and Target are both affected by this opcode, the spell from Caster will reflect off Target, but not reflect back off Caster. Previously, whoever had more reflection charges would end up victorious, now the initial target always ends up victorious.
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT reflect effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op228.html
+++ b/_opcodes/op228.html
@@ -43,6 +43,14 @@ Known values for <code>Secondary Type</code> are:
 </p>
 
 {% capture note %}
+As of EE v2.6, spells can no longer be "chained" back and forth by reflection.<br><br>
+
+If Caster and Target are both affected by this opcode, the spell from Caster will reflect off Target, but not reflect back off Caster. Previously, whoever had more reflection charges would end up victorious, now the initial target always ends up victorious.
+{% endcapture %}
+
+{% include important.html %}
+
+{% capture note %}
 <ul>
 	<li>
 		CANNOT reflect effects of Secondary Type <code><a href="../files/2da/2da_bgee/msectype.htm#4">MagicAttack</a></code>.

--- a/_opcodes/op326-bgee.html
+++ b/_opcodes/op326-bgee.html
@@ -46,8 +46,8 @@ If this effect is applied through <a href="#op177">opcode #177</a>, the spell sp
 
 {% capture note %}
 <ul>
-  <li>Unlike <a href="#op146">opcode #146</a><code><small><sup>*</sup></small>p2=1</code>, when this opcode gets reflected, the spell specified by the <code>resource</code> key is cast at the caster's Casting Level, and it will also affect the original target (as if it wasn't reflected – though it will decrement <a href="#op200">Spell Turning</a>).</li>
-  <li>When this opcode is applied through <a href="#op177">opcode #177</a> and gets reflected, the spell specified by the <code>resource</code> key is cast at the level specified at offset <code><a href="../file_formats/ie_formats/eff_v2.htm#effv2_Body_0xC8">0xc8</a></code> of the <a href="../file_formats/ie_formats/eff_v2.htm">EFF</a>, and it will also affect the original target (as if it wasn't reflected – though it will decrement <a href="#op200">Spell Turning</a>).</li>
+  <li>Unlike <a href="#op146">opcode #146</a><code><small><sup>*</sup></small>p2=1</code>, when this opcode gets reflected (<a href="#op197">opcode #197</a>, <a href="#op198">opcode #198</a>, <a href="#op199">opcode #199</a>, <a href="#op202">opcode #202</a>, <a href="#op203">opcode #203</a> and <a href="#op207">opcode #207</a>), the spell specified by the <code>resource</code> key is cast at the caster's Casting Level, and it will also affect the original target (as if it wasn't reflected).</li>
+  <li>When this opcode is applied through <a href="#op177">opcode #177</a> and gets reflected (<a href="#op197">opcode #197</a>, <a href="#op198">opcode #198</a>, <a href="#op199">opcode #199</a>, <a href="#op202">opcode #202</a>, <a href="#op203">opcode #203</a> and <a href="#op207">opcode #207</a>), the spell specified by the <code>resource</code> key is cast at the level specified at offset <code><a href="../file_formats/ie_formats/eff_v2.htm#effv2_Body_0xC8">0xc8</a></code> of the <a href="../file_formats/ie_formats/eff_v2.htm">EFF</a>, and it will also affect the original target (as if it wasn't reflected).</li>
 </ul>
 {% endcapture %}
 

--- a/_opcodes/op333-bgee.html
+++ b/_opcodes/op333-bgee.html
@@ -73,7 +73,7 @@ When using this opcode, be aware of the following quirks:
 	</li>
 
 	<li>
-		The opcode itself CANNOT be reflected, but when it would be reflected, instead only its first "hit" gets reflected (and will decrement <a href="#op200">Spell Turning</a>). Subsequent hits occur as if reflection wasn't involved. When this happens, for that first hit only:
+		When this opcode gets reflected (<a href="#op197">opcode #197</a>, <a href="#op198">opcode #198</a>, <a href="#op199">opcode #199</a>, <a href="#op202">opcode #202</a>, <a href="#op203">opcode #203</a> and <a href="#op207">opcode #207</a>), only its first "hit" gets reflected. Subsequent hits occur as if reflection wasn't involved. When this happens, for that first hit only:
 		<ul>
 			<li>If <code>subspell's projectile = 0</code>, subspell effects targeting <code>Self|Projectile Target|Original Caster</code> will affect the original caster.</li>
 			<li>If <code>subspell's projectile != 0</code>, subspell effects targeting <code>Original Caster</code> will affect the original caster.</li>


### PR DESCRIPTION
This PR is to notify modders that the decrementing reflection mechanics have been altered in the v2.6 update.

1. `Op#146(p2=2)`, `op#326` and `op#333` are now properly reflected by `op#200`, `op#227` and `op#228`.
2. Spells can no longer be "chained" back and forth by reflection (`op#200`, `op#227` and `op#228`).