### PR TITLE
Description update for PSTEE opcodes

### DIFF
--- a/_opcodes/op348-bgee.html
+++ b/_opcodes/op348-bgee.html
@@ -9,6 +9,6 @@ bgee: 1
 iwd1: 0
 iwd2: 0
 pst: 0
-pstee: 1
+pstee: 0
 ---
 Unused

--- a/_opcodes/op348-pstee.html
+++ b/_opcodes/op348-pstee.html
@@ -1,0 +1,17 @@
+---
+n: 348
+opname: "Cloak of Warding (Non-cumulative)"
+param1: "Base amount"
+param2: "Amount per level"
+bg1: 0
+bg2: 0
+bgee: 0
+iwd1: 0
+iwd2: 0
+pst: 0
+pstee: 1
+---
+The target creature will absort the amount of damage as calculated by the formula:
+<br/><code>Absorbed damage amount = 'Base amount' + ('Amount per level' * 'Caster level') + 'Dice roll'</code>
+<br/>
+<br/>Modifies SPLSTATE.IDS value CLOAK_OF_WARDING accordingly. The effect ends when all damage has been absorbed.

--- a/_opcodes/op349-bgee.html
+++ b/_opcodes/op349-bgee.html
@@ -9,6 +9,6 @@ bgee: 1
 iwd1: 0
 iwd2: 0
 pst: 0
-pstee: 1
+pstee: 0
 ---
 Unused

--- a/_opcodes/op349-pstee.html
+++ b/_opcodes/op349-pstee.html
@@ -1,0 +1,22 @@
+---
+n: 349
+opname: "Pain Mirror (Non-cumulative)"
+param1: "# damage effects to reflect"
+param2: "Unused"
+bg1: 0
+bg2: 0
+bgee: 0
+iwd1: 0
+iwd2: 0
+pst: 0
+pstee: 1
+---
+This effect reflects inflicted damage back to nearby creatures.
+<br/>
+<br/>Modifies SPLSTATE.IDS value PAIN_MIRROR accordingly. The effect is supposed to end when the specified number of damage effects have been reflected.
+
+{% capture note %}
+The effect has a bug that constantly resets the target's pain mirror counter to 'Parameter 1'. This effect will never end on its own.
+{% endcapture %}
+
+{% include bug.html %}

--- a/_opcodes/op350-bgee.html
+++ b/_opcodes/op350-bgee.html
@@ -9,6 +9,6 @@ bgee: 1
 iwd1: 0
 iwd2: 0
 pst: 0
-pstee: 1
+pstee: 0
 ---
 Unused

--- a/_opcodes/op350-pstee.html
+++ b/_opcodes/op350-pstee.html
@@ -1,0 +1,16 @@
+---
+n: 350
+opname: "Guardian Mantle (Non-cumulative)"
+param1: "Enabled?"
+param2: "Unused"
+bg1: 0
+bg2: 0
+bgee: 0
+iwd1: 0
+iwd2: 0
+pst: 0
+pstee: 1
+---
+This effect protects the target creature from physical damage.
+<br/>
+<br/>Modifies SPLSTATE.IDS value GUARDIAN_MANTLE accordingly.

--- a/_opcodes/op350-pstee.html
+++ b/_opcodes/op350-pstee.html
@@ -11,6 +11,6 @@ iwd2: 0
 pst: 0
 pstee: 1
 ---
-This effect protects the target creature from physical damage.
+This effect protects the target creature from physical damage unless the attacker makes a successful saving throw vs. spell at -4 penalty. The saving throw mechanism is hardcoded into <a href="#op12">opcode #12</a>.
 <br/>
 <br/>Modifies SPLSTATE.IDS value GUARDIAN_MANTLE accordingly.

--- a/_opcodes/op351-bgee.html
+++ b/_opcodes/op351-bgee.html
@@ -9,6 +9,6 @@ bgee: 1
 iwd1: 0
 iwd2: 0
 pst: 0
-pstee: 1
+pstee: 0
 ---
 Unused

--- a/_opcodes/op351-pstee.html
+++ b/_opcodes/op351-pstee.html
@@ -1,0 +1,20 @@
+---
+n: 351
+opname: "Armor (Non-cumulative)"
+param1: "Amount"
+param2: "Add caster level bonus?"
+bg1: 0
+bg2: 0
+bgee: 0
+iwd1: 0
+iwd2: 0
+pst: 0
+pstee: 1
+---
+Modifies SPLSTATE.IDS value ARMOR accordingly. The effect ends when all damage has been absorbed.
+
+{% capture note %}
+This effect does not give the armor class bonus as per opcode 375.
+{% endcapture %}
+
+{% include note.html %}

--- a/_opcodes/op353-pstee.html
+++ b/_opcodes/op353-pstee.html
@@ -11,13 +11,13 @@ iwd2: 0
 pst: 0
 pstee: 1
 ---
-This effect tints the screen depending on the value specified by the 'Type' field, to a colour specified by the using 'RGB Colour' field.
+This effect tints the screen depending on the value specified by the 'Type' field, to a colour specified by the 'RGB Colour' field.
 <br/>The 'RGB Colour' field is handled as follows:
 <br/>First byte = Red (0-255)
 <br/>Second byte  = Green (0-255)
 <br/>Third byte = Blue (0-255)
 <br/>
-<br/>Know values for 'Type' are:
+<br/>'Type' behavior is not yet fully understood. Known values are:
 <br/>0,1,2,3 &longrightarrow; No effect
 <br/>4,5,6,7 &longrightarrow; Instant 'RGB Colour' for the duration of the effect
 <br/>8 &longrightarrow; No effect

--- a/_opcodes/op354-pstee.html
+++ b/_opcodes/op354-pstee.html
@@ -11,4 +11,4 @@ iwd2: 0
 pst: 0
 pstee: 1
 ---
-This effects flashes the screen for a split second.
+This effects flashes the screen white for one frame.

--- a/_opcodes/op377-pstee.html
+++ b/_opcodes/op377-pstee.html
@@ -1,6 +1,6 @@
 ---
 n: 377
-opname: "Unknown"
+opname: "Speak with Dead"
 param1: "Irrelevant"
 param2: "Irrelevant"
 bg1: 0
@@ -11,4 +11,6 @@ iwd2: 0
 pst: 0
 pstee: 1
 ---
-The use of this effect is unknown, and effect of its parameters are undefined.
+This effect is used internally by projectile 205 (Stories Bones Tell).
+<br/>
+<br/>On effect removal, if <code>Global("Speak_with_Dead","GLOBAL")</code> exists, it is set to 0. The engine applies this opcode as part of projectile 205 (Stories Bones Tell) with timing=0 (Instant/Limited) and duration=300.


### PR DESCRIPTION
More descriptions for PSTEE-specific opcodes (reverse-engineered by Bubb) .

Bubb provided more details for opcode 353, but they are incomplete and rather complicated (possibly too complicated for iesdp). I'll add it here, in case you want to put them into iesdp anyway:
<details>
<summary><strong>Opcode 353, behavior bits</strong></summary>
<pre>
Behavior bits:

    param2 = 100 -> nMode1 = 0, nMode2 = 1 -> Maintains starting global lighting for the specified duration. TODO: Look into exception.

                                              Permanent duration (1) instantly terminates and has no effect.

                                              Bug(?): If param1 is more luminous than the starting global lighting, fades to param1 and terminates regardless of timing mode.

    param2 = 101 -> nMode1 = 3, nMode2 = 1 -> Temporary durations instantly set area tint to param1, then fade back to starting global lighting when duration is expired.

                                              Permanent duration (1) instantly sets area tint to param1, and does not terminate on its own unless param1
                                              happens to be the starting global lighting.

                                              Bug(?): If param1 is more luminous than the starting global lighting, fades to param1 and terminates regardless of timing mode.


    param2 = 200                           -> Supposed to fade currently active area tint back to its starting global lighting.
                                              Bug: Instantly removes active area tint, and does so without resetting sprite tint exceptions.


    (bits)
    (other) -> nMode1 = 0, nMode2 = 1                           -> Temporary durations maintain starting global lighting on bounds infringement.
                                                                   If duration expires before a bound is infringed, fades back to starting global lighting.

                                                                   Permanent duration (1) terminates on bounds infringement.

    (2)     -> nMode1 = 1, nMode2 = 2                           -> Temporary durations maintain opposite bound on bounds infringement.
                                                                   If duration expires before a bound is infringed, fades back to starting global lighting.

                                                                   Permanent duration (1) maintains bounds infringement.
                                                                   This mode is permanent and does not terminate on its own, unless the infringed bound
                                                                   happens to be the starting global lighting.

    (4)     -> nMode1 = 2, nMode2 = m_durationType == 1 ? 2 : 1 -> Temporary durations maintain first bound infringement, then fade back to starting global
                                                                   lighting when duration is expired.

                                                                   Permanent duration (1) inverts stepping and fades to the opposite bound on bounds infringement.
                                                                   This mode is permanent and does not terminate on its own. 

    (6)     -> nMode1 = 3, nMode2 = 1                           -> Temporary durations maintain first bound infringement, then fade back to starting global
                                                                   lighting when duration is expired.

                                                                   Permanent duration (1) maintains bounds infringement.
                                                                   This mode is permanent and does not terminate on its own, unless the infringed bound
                                                                   happens to be the starting global lighting.

    (!8)    -> tintMin and tintMax are automatically set to the current global lighting and param1, whichever matches.
               Step is set to the difference between param1 components and global lighting components, divided by special.

    (8)     -> tintMin is 0 (black) and tintMax is 0xFFFFFF (no tint), step is set to param1 components.
    (8 | 1) -> tintMin is 0 (black) and tintMax is 0xFFFFFF (no tint), step is set to inverted param1 components.

m_special used when:

    param2 = 100
    param2 = 101
    (param2 & BIT3) == 0
</pre>
</details>