### PR TITLE
Clarify Actor[+0x2C]

### DIFF
--- a/file_formats/ie_formats/are_v1.htm
+++ b/file_formats/ie_formats/are_v1.htm
@@ -534,7 +534,7 @@ regenerate: true
                       Created by a <a href="#formAREAV1_0_Spawn">spawn point</a> or <a href="#formAREAV1_0_Rest_Interruptions">rest interruption</a>.
                     </li>
                     <li>
-                      Spawn points with Bit 0 unset attempt to reactivate themselves by unsetting Bit 2 – a creature with this value prevents spawn points in the area from reactivating in this way. Spawn points can still reactivate by time passing.
+                      Spawn points with Bit 0 of <code>Spawn method</code> unset attempt to reactivate themselves by unsetting Bit 2 – a creature with this value prevents spawn points in the area from reactivating in this way. Spawn points can still reactivate by time passing.
                     </li>
                   </ul>
                 </li>

--- a/file_formats/ie_formats/are_v1.htm
+++ b/file_formats/ie_formats/are_v1.htm
@@ -524,7 +524,22 @@ regenerate: true
           <tr>
             <td>0x002c</td>
             <td>2 (word)</td>
-            <td>Has been spawned (0=no, 1=yes)</td>
+            <td>
+              Is random monster
+              <ul>
+                <li>0: No</li>
+                <li>1: Yes
+                  <ul>
+                    <li>
+                      Created by a <a href="#formAREAV1_0_Spawn">spawn point</a> or <a href="#formAREAV1_0_Rest_Interruptions">rest interruption</a>.
+                    </li>
+                    <li>
+                      Spawn points with Bit 0 unset attempt to reactivate themselves by unsetting Bit 2 – a creature with this value prevents spawn points in the area from reactivating in this way. Spawn points can still reactivate by time passing.
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </td>
           </tr>
           <tr>
             <td>0x002e</td>


### PR DESCRIPTION
The old note for this field was ambiguous. I've clarified that this field means that the creature was created via a spawn point or rest interruption.