### PR TITLE
Updating 'header animation' section for v1 item file format

### DIFF
--- a/file_formats/ie_formats/itm_v1.htm
+++ b/file_formats/ie_formats/itm_v1.htm
@@ -341,204 +341,513 @@ regenerate: true
     <a id="Header_Animation"><div class="actionheader">Header Animation</div></a>
     <br />
     <div class="indent1">
-      <table border="1" width="98%">
+<table border="1" width="98%">
         <colgroup>
-          <col width="30%">
-          <col width="30%">
-          <col width="30%">
+        <col width="11%">
+        <col width="11%">
+        <col width="26%">
+        <col width="26%">
+        <col width="26%">
         </colgroup>
         <thead>
           <tr>
-            <th>Value(ASCII)</th>
-            <th>Value(Hex)</th>
-            <th>Description</th>
+            <th>Value (ASCII)</th>
+            <th>Value (Hex)</th>
+            <th>BG/IWD Description</th>
+            <th>BG2 Description</th>
+            <th>Enhanced Editions Description</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>&quot; &quot;</td>
+            <td>&quot;&nbsp;&nbsp;&quot;</td>
             <td>2020h</td>
-            <td>&lt;none&gt;</td>
+            <td>No animation</td>
+            <td>No animation</td>
+            <td>No animation</td>
           </tr>
           <tr>
-            <td>&quot;2A&quot;</td>
+            <td>2A</td>
             <td>3241h</td>
+            <td>Leather Armor</td>
+            <td>Leather Armor</td>
             <td>Leather Armor</td>
           </tr>
           <tr>
-            <td>&quot;3A&quot;</td>
+            <td>2W</td>
+            <td>3257h</td>
+            <td>Robe</td>
+            <td>Robe</td>
+            <td>Robe</td>
+          </tr>
+          <tr>
+            <td>3A</td>
             <td>3341h</td>
+            <td>Chainmail</td>
+            <td>Chainmail</td>
             <td>Chainmail</td>
           </tr>
           <tr>
-            <td>&quot;4A&quot;</td>
+            <td>3W</td>
+            <td>3357h</td>
+            <td>Robe (alternate 1)</td>
+            <td>Robe (alternate 1)</td>
+            <td>Robe (alternate 1)</td>
+          </tr>
+          <tr>
+            <td>4A</td>
             <td>3441h</td>
+            <td>Plate Mail</td>
+            <td>Plate Mail</td>
             <td>Plate Mail</td>
           </tr>
           <tr>
-            <td>&quot;2W&quot;</td>
-            <td>3257h</td>
-            <td>Robe</td>
-          </tr>
-          <tr>
-            <td>&quot;3W&quot;</td>
-            <td>3357h</td>
-            <td>Robe</td>
-          </tr>
-          <tr>
-            <td>&quot;4W&quot;</td>
+            <td>4W</td>
             <td>3457h</td>
-            <td>Robe</td>
+            <td>Robe (alternate 2)</td>
+            <td>Robe (alternate 2)</td>
+            <td>Robe (alternate 2)</td>
           </tr>
           <tr>
-            <td>&quot;AX&quot;</td>
+            <td>AX</td>
             <td>4158h</td>
+            <td>Axe</td>
+            <td>Axe</td>
             <td>Axe</td>
           </tr>
           <tr>
-            <td>&quot;BW&quot;</td>
-            <td>4257h</td>
-            <td>Bow</td>
+            <td>BS</td>
+            <td>4253h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Shortbow</td>
           </tr>
           <tr>
-            <td>&quot;CB&quot;</td>
+            <td>BW</td>
+            <td>4257h</td>
+            <td>Bow</td>
+            <td>Bow</td>
+            <td>Longbow</td>
+          </tr>
+          <tr>
+            <td>C0</td>
+            <td>4330h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Small Shield (alternate 1)</td>
+          </tr>
+          <tr>
+            <td>C1</td>
+            <td>4331h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Medium Shield (alternate 1)</td>
+          </tr>
+          <tr>
+            <td>C2</td>
+            <td>4332h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Large Shield (alternate 1)</td>
+          </tr>
+          <tr>
+            <td>C3</td>
+            <td>4333h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Medium Shield (alternate 2)</td>
+          </tr>
+          <tr>
+            <td>C4</td>
+            <td>4334h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Small Shield (alternate 2)</td>
+          </tr>
+          <tr>
+            <td>C5</td>
+            <td>4335h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Large Shield (alternate 2)</td>
+          </tr>
+          <tr>
+            <td>C6</td>
+            <td>4336h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Large Shield (alternate 3)</td>
+          </tr>
+          <tr>
+            <td>C7</td>
+            <td>4337h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Medium Shield (alternate 3)</td>
+          </tr>
+          <tr>
+            <td>CB</td>
             <td>4342h</td>
+            <td>Crossbow</td>
+            <td>Crossbow</td>
             <td>Crossbow</td>
           </tr>
           <tr>
-            <td>&quot;CL&quot;</td>
+            <td>CL</td>
             <td>434Ch</td>
+            <td>Club</td>
+            <td>Club</td>
             <td>Club</td>
           </tr>
           <tr>
-            <td>&quot;D1&quot;</td>
+            <td>D1</td>
             <td>4431h</td>
+            <td>Buckler</td>
+            <td>Buckler</td>
             <td>Buckler</td>
           </tr>
           <tr>
-            <td>&quot;D2&quot;</td>
+            <td>D2</td>
             <td>4432h</td>
+            <td>Shield (Small)</td>
+            <td>Shield (Small)</td>
             <td>Shield (Small)</td>
           </tr>
           <tr>
-            <td>&quot;D3&quot;</td>
+            <td>D3</td>
             <td>4433h</td>
+            <td>Shield (Medium)</td>
+            <td>Shield (Medium)</td>
             <td>Shield (Medium)</td>
           </tr>
           <tr>
-            <td>&quot;D4&quot;</td>
+            <td>D4</td>
             <td>4434h</td>
+            <td>Shield (Large)</td>
+            <td>Shield (Large)</td>
             <td>Shield (Large)</td>
           </tr>
           <tr>
-            <td>&quot;DD&quot;</td>
+            <td>DD</td>
             <td>4444h</td>
+            <td>Dagger</td>
+            <td>Dagger</td>
             <td>Dagger</td>
           </tr>
           <tr>
-            <td>&quot;FL&quot;</td>
+            <td>F0</td>
+            <td>4630h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Flail (alternate 1)</td>
+          </tr>
+          <tr>
+            <td>F1</td>
+            <td>4631h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Flail (alternate 2)</td>
+          </tr>
+          <tr>
+            <td>F2</td>
+            <td>4632h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Flaming Short Sword</td>
+          </tr>
+          <tr>
+            <td>F3</td>
+            <td>4634h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Flail (alternate 3)</td>
+          </tr>
+          <tr>
+            <td>FL</td>
             <td>464Ch</td>
+            <td>Flail</td>
+            <td>Flail</td>
             <td>Flail</td>
           </tr>
           <tr>
-            <td>&quot;FS&quot;</td>
+            <td>FS</td>
             <td>4653h</td>
             <td>Flame Sword</td>
+            <td>Flame Sword</td>
+            <td>Flaming Long Sword</td>
           </tr>
           <tr>
-            <td>&quot;H0&quot;</td>
+            <td>GS</td>
+            <td>4753h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Glowing Staff</td>
+          </tr>
+          <tr>
+            <td>H0</td>
             <td>4830h</td>
-            <td>Small Vertical Horns</td>
+            <td>Helmet: Small Vertical Horns</td>
+            <td>Helmet: Full</td>
+            <td>Helmet: Smooth</td>
           </tr>
           <tr>
-            <td>&quot;H1&quot;</td>
+            <td>H1</td>
             <td>4831h</td>
-            <td>Large Horizontal Horns</td>
+            <td>Helmet: Large Horizontal Horns</td>
+            <td>Helmet: Large Horizontal Horns, Spiked Crest</td>
+            <td>Helmet: Five Horns</td>
           </tr>
           <tr>
-            <td>&quot;H2&quot;</td>
+            <td>H2</td>
             <td>4832h</td>
-            <td>Feather Wings</td>
+            <td>Helmet: Feather Wings</td>
+            <td>Helmet: Narrow Wings</td>
+            <td>Helmet: Feather Wings</td>
           </tr>
           <tr>
-            <td>&quot;H3&quot;</td>
+            <td>H3</td>
             <td>4833h</td>
-            <td>Top Plume</td>
+            <td>Helmet: Top Plume</td>
+            <td>Helmet: Curved Horns</td>
+            <td>Helmet: Curved Sidebars</td>
           </tr>
           <tr>
-            <td>&quot;H4&quot;</td>
+            <td>H4</td>
             <td>4834h</td>
-            <td>Dragon Wings</td>
+            <td>Helmet: Dragon Wings</td>
+            <td>Helmet: Top Plume</td>
+            <td>Helmet: Horned, Plume</td>
           </tr>
           <tr>
-            <td>&quot;H5&quot;</td>
+            <td>H5</td>
             <td>4835h</td>
-            <td>Feather Sideburns</td>
+            <td>Helmet: Feather Sideburns</td>
+            <td>Helmet: Single Crest</td>
+            <td>Helmet: Center Crest</td>
           </tr>
           <tr>
-            <td>&quot;H6&quot;</td>
+            <td>H6</td>
             <td>4836h</td>
-            <td>Large Curved Horns (incorrect paperdoll image)</td>
+            <td>Helmet: Large Curved Horns (incorrect paperdoll, unused)</td>
+            <td>Helmet: Large Curved Horns (incorrect paperdoll, unused)</td>
+            <td>Helmet: Large Curved Horns (incorrect paperdoll, unused)</td>
           </tr>
           <tr>
-            <td>&quot;HB&quot;</td>
+            <td>J0</td>
+            <td>4A30h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Smooth</td>
+          </tr>
+          <tr>
+            <td>J1</td>
+            <td>4A31h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Five Horns</td>
+          </tr>
+          <tr>
+            <td>J2</td>
+            <td>4A32h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Feather Wings with Spike</td>
+          </tr>
+          <tr>
+            <td>J3</td>
+            <td>4A33h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Curved Sidebars</td>
+          </tr>
+          <tr>
+            <td>J4</td>
+            <td>4A34h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Small Horns, Plume</td>
+          </tr>
+          <tr>
+            <td>J5</td>
+            <td>4A35h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Center Crest</td>
+          </tr>
+          <tr>
+            <td>J6</td>
+            <td>4A36h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Smooth, Two Small Horns</td>
+          </tr>
+          <tr>
+            <td>J7</td>
+            <td>4A37h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Large Horizontal Horns</td>
+          </tr>
+          <tr>
+            <td>J8</td>
+            <td>4A38h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Feather Wings without Spike</td>
+          </tr>
+          <tr>
+            <td>J9</td>
+            <td>4A39h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Full Face, Large Horns, Plume</td>
+          </tr>
+          <tr>
+            <td>JA</td>
+            <td>4A41h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Dragon Wings, Plume</td>
+          </tr>
+          <tr>
+            <td>JB</td>
+            <td>4A42h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Circlet</td>
+          </tr>
+          <tr>
+            <td>JC</td>
+            <td>4A43h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Helmet: Dragon Wings</td>
+          </tr>
+          <tr>
+            <td>HB</td>
             <td>4842h</td>
+            <td>Halberd</td>
+            <td>Halberd</td>
             <td>Halberd</td>
           </tr>
           <tr>
-            <td>&quot;MC&quot;</td>
+            <td>M2</td>
+            <td>4D32h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Mace (alternate)</td>
+          </tr>
+          <tr>
+            <td>MC</td>
             <td>4D43h</td>
+            <td>Mace</td>
+            <td>Mace</td>
             <td>Mace</td>
           </tr>
           <tr>
-            <td>&quot;MS&quot;</td>
+            <td>MS</td>
             <td>4D53h</td>
+            <td>Morning Star</td>
+            <td>Morning Star</td>
             <td>Morning Star</td>
           </tr>
           <tr>
-            <td>&quot;QS&quot;</td>
+            <td>Q2</td>
+            <td>5132h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Quarterstaff (alternate 1)</td>
+          </tr>
+          <tr>
+            <td>Q3</td>
+            <td>5133h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Quarterstaff (alternate 2)</td>
+          </tr>
+          <tr>
+            <td>Q4</td>
+            <td>5134h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Quarterstaff (alternate 3)</td>
+          </tr>
+          <tr>
+            <td>QS</td>
             <td>5153h</td>
-            <td>Quarter Staff (Metal)</td>
+            <td>Quarterstaff</td>
+            <td>Quarterstaff</td>
+            <td>Quarterstaff</td>
           </tr>
           <tr>
-            <td>&quot;S1&quot;</td>
+            <td>S0</td>
+            <td>5330h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>One-Handed Sword: Bastard</td>
+          </tr>
+          <tr>
+            <td>S1</td>
             <td>5331h</td>
-            <td>Sword 1-Handed</td>
+            <td>One-Handed Sword: Bastard/Broad/Long/Scimitar</td>
+            <td>One-Handed Sword: Bastard/Broad/Long</td>
+            <td>One-Handed Sword: Broad/Long</td>
           </tr>
           <tr>
-            <td>&quot;S2&quot;</td>
+            <td>S2</td>
             <td>5332h</td>
-            <td>Sword 2-Handed</td>
+            <td>Twp-Handed Sword </td>
+            <td>Twp-Handed Sword </td>
+            <td>Twp-Handed Sword </td>
           </tr>
           <tr>
-            <td>&quot;SL&quot;</td>
+            <td>S3</td>
+            <td>5333h</td>
+            <td>n/a</td>
+            <td>One-Handed Sword: Katana</td>
+            <td>One-Handed Sword: Katana</td>
+          </tr>
+          <tr>
+            <td>SC</td>
+            <td>5343h</td>
+            <td>n/a</td>
+            <td>One-Handed Sword: Scimitar</td>
+            <td>One-Handed Sword: Scimitar</td>
+          </tr>
+          <tr>
+            <td>SL</td>
             <td>534Ch</td>
+            <td>Sling</td>
+            <td>Sling</td>
             <td>Sling</td>
           </tr>
           <tr>
-            <td>&quot;SP&quot;</td>
+            <td>SP</td>
             <td>5350h</td>
+            <td>Spear</td>
+            <td>Spear</td>
             <td>Spear</td>
           </tr>
           <tr>
-            <td>&quot;SS&quot;</td>
+            <td>SS</td>
             <td>5353h</td>
-            <td>Short Sword</td>
+            <td>One-Handed Sword: Short</td>
+            <td>One-Handed Sword: Short</td>
+            <td>One-Handed Sword: Short</td>
           </tr>
           <tr>
-            <td>&quot;WH&quot;</td>
+            <td>WH</td>
             <td>5748h</td>
+            <td>War Hammer</td>
+            <td>War Hammer</td>
             <td>War Hammer</td>
           </tr>
           <tr>
-            <td>&quot;S3&quot;</td>
-            <td>5333h</td>
-            <td>Katana #</td>
-          </tr>
-          <tr>
-            <td>&quot;SC&quot;</td>
-            <td>5343h</td>
-            <td>Scimitar #</td>
+            <td>ZW</td>
+            <td>5A57h</td>
+            <td>n/a</td>
+            <td>n/a</td>
+            <td>Wings (female)</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
The EEs are built with One Pixel Production's expanded animations, resulting in valid values for this field not being documented for the EEs.

Also documented the minor differences between the BG/IWD and BG2 animations, specifically the difference in helmet appearance and the availability of the S3 (katana)/SC (scimitar) animations. While the shield cosmetics also vary, I didn't document this as they're internally consistent within the games.