### PR TITLE
Fixes incorrectly available orientations in animation type 4000.

### DIFF
--- a/file_formats/ie_formats/ini_anim.htm
+++ b/file_formats/ie_formats/ini_anim.htm
@@ -354,8 +354,8 @@ title: "INI file format: Creature Animations"
       - SC=0-15, SD=16-31, GH=32-47, DE=48-63, TW=64-79<br />
       <br />
       Available orientations (sequence &rarr; direction):<br />
-      - 0 &rarr; S, 1 &rarr; S, 2 &rarr; SW, 3 &rarr; SW, 4 &rarr; W, 5 &rarr; W, 6 &rarr; NW, 7 &rarr; NW, 8 &rarr; N, 9 &rarr; N<br />
-      - 10 &rarr; NE, 11 &rarr; NE, 12 &rarr; E, 13 &rarr; E, 14 &rarr; SE, 15 &rarr; SE<br />
+      - 0 &rarr; S, 1 &rarr; SSW, 2 &rarr; SW, 3 &rarr; WSW, 4 &rarr; W, 5 &rarr; WNW, 6 &rarr; NW, 7 &rarr; NNW, 8 &rarr; N, 9 &rarr; NNE<br />
+      - 10 &rarr; NE, 11 &rarr; ENE, 12 &rarr; E, 13 &rarr; ESE, 14 &rarr; SE, 15 &rarr; SSE<br />
       <br />
       The following attributes are supported:<br />
       <ul>


### PR DESCRIPTION
See: https://www.gibberlings3.net/forums/topic/39929-type-4000-town_static-available-orientations

**ISSUE:**

_Available orientations (sequence → direction):_
- 0 → S, 1 → S, 2 → SW, 3 → SW, 4 → W, 5 → W, 6 → NW, 7 → NW, 8 → N, 9 → N
- 10 → NE, 11 → NE, 12 → E, 13 → E, 14 → SE, 15 → SE
 

The sum of the 16 orientations is correct, but some of the names are possibly incorrect.

**EXAMPLE:** 

- SSIMC.BAM (BG2EE)

Assuming based on this example(SSIMC.BAM) and type 1000 (monster_multi) it should be:

_Available orientations (sequence → direction):_
- 0 → S, 1 → SSW, 2 → SW, 3 → WSW, 4 → W, 5 → WNW, 6 → NW, 7 → NNW, 8 → N

- 9 → NNE, 10 → NE, 11 → ENE, 12 → E, 13 → ESE, 14 → SE, 15 → SSE