### PR TITLE
Fixes sequence name in Type 9000(monster_large).

### DIFF
--- a/file_formats/ie_formats/ini_anim.htm
+++ b/file_formats/ie_formats/ini_anim.htm
@@ -664,7 +664,7 @@ title: "INI file format: Creature Animations"
       - <span class="mono">G1E</span>: SD=5-7, SC=13-15, WK=21-23<br />
       - <span class="mono">G2</span>: A1=0-4, A2=8-12<br />
       - <span class="mono">G2E</span>: A1=5-7, A2=13-15<br />
-      - <span class="mono">G3</span>: A3=0-4, GH2=8-12, DE=16-20, TW=24-28<br />
+      - <span class="mono">G3</span>: A3=0-4, GH=8-12, DE=16-20, TW=24-28<br />
       - <span class="mono">G3E</span>: A3=5-7, GH=13-15, DE=21-23, TW=29-31<br />
       <br />
       Available orientations (sequence &rarr; direction):<br />


### PR DESCRIPTION
Source: https://gibberlings3.github.io/iesdp/file_formats/ie_formats/ini_anim.htm#formINI_type_9000

**ISSUE:**
- G3: A3=0-4, GH2=8-12, DE=16-20, TW=24-28
- G3E: A3=5-7, GH=13-15, DE=21-23, TW=29-31

_GH2 in G3 makes no sense due to following reasons:_

- G3E is the east-side representation of the animations in sequence G3, so it should be either GH2 or GH.
- GH is defined in iesdp, but GH2 is not. In fact, it only appears once in the search count.

 **EXAMPLE:**
- MOGRG3(E).BAM