### PR TITLE
Fixes the incorrect attack/spell sequence for type 7000 (monster_old)

### DIFF
--- a/file_formats/ie_formats/ini_anim.htm
+++ b/file_formats/ie_formats/ini_anim.htm
@@ -605,8 +605,8 @@ title: "INI file format: Creature Animations"
       seq:<br />
       - <span class="mono">G1</span>: WK=0-4, SC=8-12, SD=16-20, GH=24-28, DE=32-36, TW=40-44<br />
       - <span class="mono">G1E</span>: WK=5-7, SC=13-15, SD=21-23, GH=29-31, DE=37-39, TW=45-47<br />
-      - <span class="mono">G2</span>: A1=0-4, CA=8-12, A3=16-20<br />
-      - <span class="mono">G2E</span>: A1=5-7, CA=13-15, A3=21-23<br />
+      - <span class="mono">G2</span>: A1=0-4, A3=8-12, CA=16-20<br />
+      - <span class="mono">G2E</span>: A1=5-7, A3=13-15, CA=21-23<br />
       <br />
       Available orientations (sequence &rarr; direction):<br />
       - 0 &rarr; S, 1 &rarr; SW, 2 &rarr; W, 3 &rarr; NW, 4 &rarr; N<br />


### PR DESCRIPTION
This was discovered by creating a custom wolf model.

The Winter Wolf uses the same animation BAM files as the Wolf (see resref in 7b000.INI for the Wolf and 7b03.INI for the Winter Wolf).

The original BAM files (MWLFG2.bam and MWLFG2E.bam) contain the same attack sprites for both CA and A3, making it unclear which is used for casting and which for attacks.

Using the custom-created Wolf animation BAM files revealed the faulty sequences, as these use distinct animation sprites for CA and A3.

Here you will find the files for reproducibility and verification:
[WinterwolfAnimation.zip](https://github.com/user-attachments/files/25898779/WinterwolfAnimation.zip)

1. Copy the contents into the "Override" folder.
2. Use `C:CreateCreature("wolfwi")` to create a winterwolf
3. Let winterwolf attack from distance

NOTE:
The file WOLFWI.CRE in the zip archive only contains the change of the animation attribute to Wolf, so that there are no color bleedings in the model, as different color palettes are used (see file 7b03.INI `new_palette=MWLF_WI`).