### PR TITLE
fix(op18): special BIT0 do not update current HP (not just the value 1)

### DIFF
--- a/_opcodes/op018.html
+++ b/_opcodes/op018.html
@@ -30,7 +30,7 @@ Applies the modifier value specified by the <code>Statistic Modifier</code> fiel
 <ul>
 	<li>0 &longrightarrow; Normal: Effect functions as dictated by the <code>Type</code> field.</li>
 	<li>
-		1 &longrightarrow; Do not update current HP.
+		BIT0 &longrightarrow; Do not update current HP.
 		<ul>
 			<li>This value is set automatically once the effect has been initially processed on a creature.</li>
 			<li>For normal operation, the special field MUST be zero.</li>


### PR DESCRIPTION
Hey,
this is a quick fix.